### PR TITLE
Fix extension not being able to find "About" element

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -122,7 +122,7 @@ function formatDate(date, format) {
  */
 function injectDateToHTML(date) {
   const h2Elems = Array.from(
-    document.querySelectorAll('.repository-content .BorderGrid-cell > h2')
+    document.querySelectorAll('.repository-content .BorderGrid-cell h2')
   );
 
   const aboutElementContainer = h2Elems.find(


### PR DESCRIPTION
Github have updated the repo page nesting the "About" element in another div which was causing this extension to fail. This quick change fixes that :)